### PR TITLE
Reposition: Well -> Position

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Python Django models for liquid in plates and tubes
 For planning what should happen, with strong constraints, and tracking what actually happened.
 
 ## Features
-* Prevent out-of-range well rows and columns
+* Prevent out-of-range rows and columns
 * Generate identifying codes (ready to be printed out as barcodes)
 * Record externally generated barcodes (track pre-barcoded tubes and plates)
 

--- a/documentation/design.md
+++ b/documentation/design.md
@@ -13,12 +13,15 @@ We should keep in mind the risk reduction benefits of graduating software from 1
 testing, to 2. RUO production use, feedback, and software iteration, to 3. CGMP production use.
 
 ## Models
-### Containers
-To support plates, a `Container` models a two-dimensional matrix of `Well`s. Tubes are treated as
-a degenerate case with a single row and a single column. For easy checking, the coordinate system
-matches what is commonly molded onto plates, with a character for the row and a number for the
-column. Zero padding to a uniform width is performed to make sorting exported data easy, for
-tidy display.
+### Container
+To support plates, a `Container` models a two-dimensional matrix of `Position`s. Treat individual
+tubes as a simple or "degenerate" case with one row and one column. When multiple tubes are held in
+one or more physical racks, holders, or fixtures, they can be treated as one logical `Container`
+with rows and columns convenient multiples of the physical racks.
+
+For easy checking, the coordinate system matches the "Battleship notation" commonly molded onto
+plates, with a character for the row and a number for the column. Zero padding to a uniform width
+makes sorting exported data easy, and keeps displays tidy.
 
 To avoid mixups, each `Container` is assigned a unique alphanumberic human and machine readable
 identifier called `code`. It is designed to support the following physical labeling:
@@ -28,30 +31,27 @@ identifier called `code`. It is designed to support the following physical label
 * Printing and sticking a barcode representation of the letters and numbers to the `Container`
 * Scanning pre-barcoded `Containers` and recording their values in the database
 
-Tubes in a rack can be modeled as many single-`Well` `Container`s. This is a good choice when
-the tubes are only in this arrangement for one workflow step. If helpful, information about the
-rack can be recorded in related `Plan` or `Result` objects.
+### Format
+The number of rows and columns in a `Container`, and intended usage and code prefix, define a
+`Format`.
 
-Tubes in a rack can also be modeled as one multi-`Well` `Container`. This is a good choice when
-the tubes remain in the same arrangement for multiple workflow steps. If helpful, information
-about the tubes, such as tube-specific barcodes, can be be recorded in related `Plan` or `Result`
-objects.
 
+### System Limits
 Separate models per `Format`, and a unified model with separately incrementing numbers per prefix,
 were considered, but the code complexity of those approaches seems unwarranted. The first model to
-overflow will probably be `Well`. The maximum value for BigAutoField is 9223372036854775807. If
-`Well`s were fully populated, 9223372036854775807 // 384 == 24019198012642645 (17 digits)
-`Containers` would be supported. If `Well`s are sparsely populated and plates have 384
+overflow will probably be `Position`. The maximum value for BigAutoField is 9223372036854775807. If
+`Position`s were fully populated, 9223372036854775807 // 384 == 24019198012642645 (17 digits)
+`Containers` would be supported. If `Positions`s are sparsely populated and plates have 384
 or fewer wells, then the limit is a bit higher.
 
 Horizontal space for printing barcodes might be more limiting than database integer size. To start
-with, the maximum allowed width is twelve characters. A more end-to-end check would be to generate
+with, the maximum allowed `code` width is twelve characters. A more end-to-end check would be to generate
 a label and check that everything fits, but wellplated does not yet include label generation.
 
 While resource exhaustion is a common failure mode, it is easy to track and forecast. TODO: extend
 django-healthcheck for AutoField/BigAutoField exhaustion, somewhat similar to free disk space.
 
-#### Future Work
+#### Large Plates
 Plates with double-character (more than 26) rows are not yet supported because of open questions.
 
 https://web.archive.org/web/20210506171929/http://mscreen.lsi.umich.edu/mscreenwiki/index.php/COORDINATE
@@ -74,4 +74,4 @@ Some plates appear to have physical molding assigning four wells at a time to a 
 https://shop.gbo.com/en/usa/products/bioscience/microplates/1536-well-microplates/
 I'm guessing then that AA1, AB2, ..., HC47, HD48 would describe the diagonal.
 
-Should only one of these be supported? Should both be supported?
+Should only one of these be supported? Should both be supported? Are there other conventions?

--- a/documentation/vocabulary.md
+++ b/documentation/vocabulary.md
@@ -1,12 +1,13 @@
 Consistent use of clear, short words should make wellplated easy to understand.
 This document maps chosen terms (heading) to possible alternatives (list items).
 
-## Well
+## Position
+A tube has a position in a rack, a well has a position in a plate.
 Possible synonyms:
 * Coordinate
 * Label
-* Position
-* Row-column pair
+* Well
+* Row-column pair/2-tuple
 
 ## Source
 Possible synonyms:
@@ -72,7 +73,7 @@ https://www.accessdata.fda.gov/scripts/cdrh/cfdocs/cfcfr/CFRSearch.cfm?fr=210.3 
 * Unit
 * Gang-printed labeling
 
-https://www.accessdata.fda.gov/scripts/cdrh/cfdocs/cfcfr/CFRSearch.cfm?CFRPart=211&showFR=1&subpartNode=21:4.0.1.1.11.2
+https://www.ecfr.gov/current/title-21/section-211.22
 * Production records
 * Laboratory facilities
 * Testing
@@ -91,7 +92,7 @@ https://www.accessdata.fda.gov/scripts/cdrh/cfdocs/cfcfr/CFRSearch.cfm?fr=600.3
 * Label
 * Specification
 
-https://www.accessdata.fda.gov/scripts/cdrh/cfdocs/cfcfr/CFRSearch.cfm?CFRPart=211&showFR=1&subpartNode=21:4.0.1.1.11.3
+https://www.ecfr.gov/current/title-21/section-211.42
 * Mixups
 * Flow of ... in-process materials ...
 * Operations

--- a/justfile
+++ b/justfile
@@ -1,0 +1,33 @@
+set export
+set shell := ['bash', '-euo', 'pipefail', '-c']
+
+default:
+    @just --list
+
+# print CodeNAme, a four letter acronym
+cona:
+    #!/usr/bin/env bash
+    if [[ $GITHUB_REPOSITORY ]]; then
+        echo "${GITHUB_REPOSITORY##*/}"
+    elif [[ $VIRTUAL_ENV ]]; then
+        basename "${VIRTUAL_ENV%/.venv}"
+    else
+        basename "$PWD"
+    fi
+
+# print ORGanizatioN, a four letter acronym
+orgn:
+    #!/bin/bash
+    if [[ -n ${GITHUB_REPOSITORY_OWNER-} ]]; then
+        echo "$GITHUB_REPOSITORY_OWNER";
+    else
+        git remote get-url origin | sed -E 's,.+github.com/([^/]+).+,\1,';
+    fi
+
+# git PUSH over https
+push *args:
+    git push https://${GITHUB_TOKEN}@github.com/$(just orgn)/$(just cona) {{args}}
+
+# run TESTs and report uncovered lines
+test:
+    python -m pytest --cov="$(just cona)" --cov-report=term-missing:skip-covered --verbose

--- a/wellplated/admin.py
+++ b/wellplated/admin.py
@@ -2,11 +2,9 @@ from typing import Self
 
 from django.contrib.admin import ModelAdmin, TabularInline, register
 from django.forms import Media
-from django.http import HttpRequest, HttpResponse
-from django.template.response import TemplateResponse
 from django.utils.safestring import SafeText
 
-from wellplated.models import Container, Format, Well
+from wellplated.models import Container, Format, Position
 
 
 @register(Format)
@@ -21,8 +19,7 @@ class FormatAdmin(ModelAdmin):
         'created_at',
     )
     readonly_fields = ('diagram', 'my_bottom_right_prefix', 'bottom_right_prefix', 'created_at')
-    
-    
+
     def my_bottom_right_prefix(self: Self, instance: Format) -> SafeText:
         """
         div with database value, plus alpinejs to provide a client-side preview
@@ -32,9 +29,7 @@ class FormatAdmin(ModelAdmin):
         html = '<div>'
         for field in ('bottom_row', 'right_column', 'prefix'):
             html += f'<span x-text="{field}">{getattr(instance, field)}</span>'
-        return SafeText(
-            html + '</div>'
-        )
+        return SafeText(html + '</div>')
 
     def diagram(self: Self, instance: Format) -> SafeText:
         style = 'style="text-align: center; text-transform: none; vertical-align: middle;"'
@@ -61,13 +56,13 @@ class FormatAdmin(ModelAdmin):
         return super().media + Media(css={'all': ['wellplated.css']}, js=['//unpkg.com/alpinejs'])
 
 
-class WellInline(TabularInline):
-    model = Well
+class PositionInline(TabularInline):
+    model = Position
     extra = 0
 
 
 @register(Container)
 class ContainerAdmin(ModelAdmin):
-    inlines = (WellInline,)
+    inlines = (PositionInline,)
     list_display = ('code', 'format', 'created_at')
     readonly_fields = ('code', 'created_at')

--- a/wellplated/admin.py
+++ b/wellplated/admin.py
@@ -18,18 +18,7 @@ class FormatAdmin(ModelAdmin):
         'prefix',
         'created_at',
     )
-    readonly_fields = ('diagram', 'my_bottom_right_prefix', 'bottom_right_prefix', 'created_at')
-
-    def my_bottom_right_prefix(self: Self, instance: Format) -> SafeText:
-        """
-        div with database value, plus alpinejs to provide a client-side preview
-        of the GeneratedField, which concatenates bottom_row, right_column, and prefix
-        """
-        print('covdebug')
-        html = '<div>'
-        for field in ('bottom_row', 'right_column', 'prefix'):
-            html += f'<span x-text="{field}">{getattr(instance, field)}</span>'
-        return SafeText(html + '</div>')
+    readonly_fields = ('diagram', 'bottom_right_prefix', 'created_at')
 
     def diagram(self: Self, instance: Format) -> SafeText:
         style = 'style="text-align: center; text-transform: none; vertical-align: middle;"'
@@ -52,8 +41,7 @@ class FormatAdmin(ModelAdmin):
 
     @property
     def media(self) -> Media:
-        # TODO set defer attribute for alpinejs
-        return super().media + Media(css={'all': ['wellplated.css']}, js=['//unpkg.com/alpinejs'])
+        return super().media + Media(css={'all': ['wellplated.css']}) 
 
 
 class PositionInline(TabularInline):

--- a/wellplated/admin.py
+++ b/wellplated/admin.py
@@ -41,7 +41,7 @@ class FormatAdmin(ModelAdmin):
 
     @property
     def media(self) -> Media:
-        return super().media + Media(css={'all': ['wellplated.css']}) 
+        return super().media + Media(css={'all': ['wellplated.css']})
 
 
 class PositionInline(TabularInline):

--- a/wellplated/admin.py
+++ b/wellplated/admin.py
@@ -9,7 +9,6 @@ from wellplated.models import Container, Format, Position
 
 @register(Format)
 class FormatAdmin(ModelAdmin):
-    change_form_template = 'change_form.html.j2'
     list_display = (
         'bottom_right_prefix',
         'purpose',

--- a/wellplated/fields.py
+++ b/wellplated/fields.py
@@ -8,13 +8,12 @@ Models with consistent checks at every level
 """
 
 from functools import partial
-from typing import Any, Self, Sequence, cast
+from typing import Any, Self, cast
 
 from django.db.models import CharField, CheckConstraint, Model, PositiveSmallIntegerField, Q, Value
 from django.db.models.functions import Cast, Left, Length, Substr
 from django.db.models.options import Options
 from django.forms import ChoiceField, Field
-from django.forms.widgets import Widget
 
 CharField.register_lookup(Length)
 

--- a/wellplated/fields.py
+++ b/wellplated/fields.py
@@ -156,7 +156,6 @@ class CheckedCharField(CharField):
             if self.min_value and self.max_value:
                 help_text += f', {self.min_value}..{self.max_value}'
             field.help_text = help_text
-            field.widget.attrs['x-model'] = self.attname
         return field
 
 
@@ -254,5 +253,4 @@ class CheckedPositiveSmallIntegerField(PositiveSmallIntegerField):
             **{'min_value': self.min_value, 'max_value': self.max_value, **kwargs}
         ):
             field.help_text = f'number {self.min_value}..{self.max_value}'
-            field.widget.attrs['x-model'] = self.attname
         return field

--- a/wellplated/fields.py
+++ b/wellplated/fields.py
@@ -8,12 +8,13 @@ Models with consistent checks at every level
 """
 
 from functools import partial
-from typing import Any, Self, cast
+from typing import Any, Self, Sequence, cast
 
 from django.db.models import CharField, CheckConstraint, Model, PositiveSmallIntegerField, Q, Value
 from django.db.models.functions import Cast, Left, Length, Substr
 from django.db.models.options import Options
 from django.forms import ChoiceField, Field
+from django.forms.widgets import Widget
 
 CharField.register_lookup(Length)
 
@@ -156,6 +157,7 @@ class CheckedCharField(CharField):
             if self.min_value and self.max_value:
                 help_text += f', {self.min_value}..{self.max_value}'
             field.help_text = help_text
+            field.widget.attrs['x-model'] = self.attname
         return field
 
 
@@ -253,4 +255,5 @@ class CheckedPositiveSmallIntegerField(PositiveSmallIntegerField):
             **{'min_value': self.min_value, 'max_value': self.max_value, **kwargs}
         ):
             field.help_text = f'number {self.min_value}..{self.max_value}'
+            field.widget.attrs['x-model'] = self.attname
         return field

--- a/wellplated/migrations/0001_initial.py
+++ b/wellplated/migrations/0001_initial.py
@@ -60,15 +60,15 @@ def constrain_models() -> list[migrations.AddConstraint]:
                 'wellplated_container.external_id <= 99999999999',
                 Q(external_id__lte=int('9' * (PREFIX_ID_LENGTH - 1))),
             ),
-            ('len(wellplated_well.row) == 1', Q(row__length=1)),
-            ("wellplated_well.row >= 'A'", Q(row__gte='A')),
+            ('len(wellplated_position.row) == 1', Q(row__length=1)),
+            ("wellplated_position.row >= 'A'", Q(row__gte='A')),
             (
-                'wellplated_well.row <= wellplated_well.container[:1]',
+                'wellplated_position.row <= wellplated_position.container[:1]',
                 Q(row__lte=Left('container', 1)),
             ),
-            ('wellplated_well.column >= 1', Q(column__gte=1)),
+            ('wellplated_position.column >= 1', Q(column__gte=1)),
             (
-                'wellplated_well.column <= int(wellplated_well.container[1:3])',
+                'wellplated_position.column <= int(wellplated_position.container[1:3])',
                 Q(column__lte=Cast(Substr('container', 2, 2), PositiveSmallIntegerField())),
             ),
         )
@@ -77,7 +77,7 @@ def constrain_models() -> list[migrations.AddConstraint]:
             constraint=UniqueConstraint(
                 fields=('container', 'row', 'column'), name='unique_container_row_column'
             ),
-            model_name='well',
+            model_name='position',
         )
     ]
 
@@ -96,8 +96,8 @@ def create_untracked(apps: state.StateApps, _schema_editor: BaseDatabaseSchemaEd
                 bottom_row='A', right_column=1, prefix=purpose, purpose=purpose
             ),
         )
-        container.wells.add(apps.get_model('wellplated', 'Well')(row='A', column=1))
-        container.wells.commit()
+        container.positions.add(apps.get_model('wellplated', 'Position')(row='A', column=1))
+        container.positions.commit()
 
 
 class Migration(migrations.Migration):
@@ -197,7 +197,7 @@ class Migration(migrations.Migration):
             options={'abstract': False},
         ),
         migrations.CreateModel(
-            name='Well',
+            name='Position',
             fields=[
                 (
                     'id',
@@ -211,7 +211,7 @@ class Migration(migrations.Migration):
                         db_column='container_code',
                         editable=False,
                         on_delete=PROTECT,
-                        related_name='wells',
+                        related_name='positions',
                         to='wellplated.container',
                         to_field='code',
                     ),
@@ -262,15 +262,18 @@ class Migration(migrations.Migration):
                     'plan',
                     ForeignKey(on_delete=PROTECT, related_name='transfers', to='wellplated.plan'),
                 ),
-                ('source', ForeignKey(on_delete=PROTECT, related_name='+', to='wellplated.well')),
-                ('sink', ForeignKey(on_delete=PROTECT, related_name='+', to='wellplated.well')),
+                (
+                    'source',
+                    ForeignKey(on_delete=PROTECT, related_name='+', to='wellplated.position'),
+                ),
+                ('sink', ForeignKey(on_delete=PROTECT, related_name='+', to='wellplated.position')),
             ],
         ),
         migrations.AddField(
-            model_name='well',
+            model_name='position',
             name='sinks',
             field=ManyToManyField(
-                related_name='sources', through='wellplated.Transfer', to='wellplated.well'
+                related_name='sources', through='wellplated.Transfer', to='wellplated.position'
             ),
         ),
     )

--- a/wellplated/models.py
+++ b/wellplated/models.py
@@ -6,6 +6,7 @@ from typing import ClassVar, Self
 from django.contrib.auth.models import User
 from django.db.models import (
     PROTECT,
+    BooleanField,
     CharField,
     DateTimeField,
     ForeignKey,
@@ -46,7 +47,7 @@ def global_admin_css() -> str:
     )
 
 
-# type issue night be caused by ClusterableModel missing type annotations
+# type issue might be caused by ClusterableModel missing type annotations
 # https://github.com/typeddjango/django-stubs/issues/1023
 class Format(Model):  # type: ignore[django-manager-missing]
     """
@@ -77,7 +78,7 @@ class Format(Model):  # type: ignore[django-manager-missing]
     # in its own GeneratedFields, and Well can ForeignKey and constrain on them.
     bottom_right_prefix = GeneratedField(
         db_persist=True,
-        # editable=False,
+        editable=False,
         expression=Concat(
             'bottom_row', LPad(Cast('right_column', CharField()), 2, Value('0')), 'prefix'
         ),
@@ -86,8 +87,6 @@ class Format(Model):  # type: ignore[django-manager-missing]
         ),
         unique=True,
     )
-
-    attribute_example = 'Attribute example'
 
     created_at = DateTimeField(auto_now_add=True)
 
@@ -189,7 +188,7 @@ class Position(Model):
     One of multiple positions on a plate, or the singular position of a vial, tube, or trough.
 
     Positions are stored and displayed in "Battleship notation" with alphabetical row and
-    numerical column. For easy sorting and consistent length, the former is one characting
+    numerical column. For easy sorting and consistent length, the former is one character
     beginning with `A`, and the latter is zero padded two digits beginning with `01`.
 
     1-well   vial/tube/trough position  A01
@@ -264,7 +263,7 @@ class Transfer(Model):
     Movement from one position to another.
 
     The same (source, sink) may appear multiple times in the same plan to enable transferring
-    a volume exceeding pipette or tip size.
+    a volume exceeding the pipette or tip size.
 
     The same (source, sink) may appear in multiple plans to enable multiple rounds of
     liquid transfer and drying.

--- a/wellplated/models.py
+++ b/wellplated/models.py
@@ -6,7 +6,6 @@ from typing import ClassVar, Self
 from django.contrib.auth.models import User
 from django.db.models import (
     PROTECT,
-    BooleanField,
     CharField,
     DateTimeField,
     ForeignKey,

--- a/wellplated/models.py
+++ b/wellplated/models.py
@@ -6,7 +6,6 @@ from typing import ClassVar, Self
 from django.contrib.auth.models import User
 from django.db.models import (
     PROTECT,
-    BooleanField,
     CharField,
     DateTimeField,
     ForeignKey,
@@ -32,7 +31,7 @@ from wagtail.snippets.views.snippets import SnippetViewSet
 
 from wellplated.fields import CheckedCharField, CheckedPositiveSmallIntegerField
 
-LABEL_384 = compile(r'^(?P<row>[A-P])(?P<column>[012]?[0-9])$')
+POSITIONS_384 = compile(r'^(?P<row>[A-P])(?P<column>[012]?[0-9])$')
 PREFIX_ID_LENGTH = 12  # TODO make this configurable
 CONTAINER_CODE_LENGTH = 1 + 2 + PREFIX_ID_LENGTH  # bottom row, right column
 
@@ -69,7 +68,7 @@ class Format(Model):  # type: ignore[django-manager-missing]
     prefix = CheckedCharField(
         max_length=PREFIX_ID_LENGTH - 1,
         min_length=0,
-        omits='.',  # Dot/period separates Container serial code from Well label
+        omits='.',  # Dot/period separates Container serial code from Well position
         unique=True,
     )
 
@@ -78,7 +77,7 @@ class Format(Model):  # type: ignore[django-manager-missing]
     # in its own GeneratedFields, and Well can ForeignKey and constrain on them.
     bottom_right_prefix = GeneratedField(
         db_persist=True,
-        #editable=False,
+        # editable=False,
         expression=Concat(
             'bottom_row', LPad(Cast('right_column', CharField()), 2, Value('0')), 'prefix'
         ),
@@ -87,13 +86,13 @@ class Format(Model):  # type: ignore[django-manager-missing]
         ),
         unique=True,
     )
-    
+
     attribute_example = 'Attribute example'
 
     created_at = DateTimeField(auto_now_add=True)
 
     # Optimization: variable length fields last
-    purpose = TextField(blank=False, unique=True)  # How the contents of wells should be interpreted
+    purpose = TextField(blank=False, unique=True)  # How contents should be interpreted
     # TODO forms.fields.TextField(min_length=1)
 
     def __str__(self) -> str:
@@ -112,7 +111,7 @@ register_snippet(Format, FormatViewSet)
 
 @register_snippet
 class Container(ClusterableModel):
-    """A Container is uniquely identified by its serial code and has Wells"""
+    """A Container is uniquely identified by its serial code and has Positions"""
 
     external_id = CheckedPositiveSmallIntegerField(
         blank=True, default=None, max_value=int('9' * (PREFIX_ID_LENGTH - 1)), null=True
@@ -145,58 +144,59 @@ class Container(ClusterableModel):
     panels = (
         FieldPanel('created_at', read_only=True),
         FieldPanel('format', read_only=True),
-        InlinePanel('wells'),
+        InlinePanel('positions'),
     )
 
-    wells: Manager['Well']
+    positions: Manager['Position']
 
-    def __getattr__(self, label: str) -> 'Well | None':
+    def __getattr__(self, position: str) -> 'Position | None':
         # These attributes seem to be added after __init__ but raising an AttributeError for them
         # breaks the the Django admin and Wagtail manage interfaces.
-        if label in ('code', 'format'):
+        if position in ('code', 'format'):
             return None
 
-        label_match = LABEL_384.match(label)
-        if not label_match or label_match.groupdict().keys() != {'row', 'column'}:
+        position_match = POSITIONS_384.match(position)
+        if not position_match or position_match.groupdict().keys() != {'row', 'column'}:
             # ClusterableModel and maybe other code catches AttributeError but not DoesNotExist.
             # Observed with the following attributes:
             # _cluster_related_objects, _prefetched_objects_cache, get_source_expressions,
             # resolve_expression
-            raise AttributeError(f'Failed to parse {label}')  # noqa: TRY003
-        column = int(label_match.groupdict()['column'], 10)
+            raise AttributeError(f'Failed to parse {position}')  # noqa: TRY003
+        column = int(position_match.groupdict()['column'], 10)
 
-        return self.wells.get(row=label_match.groupdict()['row'], column=column)
+        return self.positions.get(row=position_match.groupdict()['row'], column=column)
 
     def __str__(self) -> str:
         return self.code[1 + 2 :]  # row, column
 
 
-class WellManager(Manager['Well']):
-    """Customize Well.objects."""
+class PositionManager(Manager['Position']):
+    """Customize Position.objects."""
 
     @property
-    def start(self) -> 'Well':
-        """Return the special infinite source well."""
+    def start(self) -> 'Position':
+        """Return the special infinite source position."""
         return self.get(container='A01start0000000', row='A', column=1)
 
     @property
-    def end(self) -> 'Well':
-        """Return the special infinite sink well."""
+    def end(self) -> 'Position':
+        """Return the special infinite sink position."""
         return self.get(container='A01end000000999', row='A', column=1)
 
 
-class Well(Model):
+class Position(Model):
     """
-    One of multiple positions on a plate, or the singular position of a tube.
+    One of multiple positions on a plate, or the singular position of a vial, tube, or trough.
 
-    Positions are stored and displayed as "Battleship notation" labels with alphabetical row and
-    numerical column, the latter zero-padded for easy sorting and consistent length.
+    Positions are stored and displayed in "Battleship notation" with alphabetical row and
+    numerical column. For easy sorting and consistent length, the former is one characting
+    beginning with `A`, and the latter is zero padded two digits beginning with `01`.
 
-    1-well   tube/trough  coordinate is   A01
-    6-well   plate coordinates range from A01 to B03
-    24-well  plate coordinates range from A01 to D06
-    96-well  plate coordinates range from A01 to H12
-    384-well plate coordinates range from A01 to P24
+    1-well   vial/tube/trough position  A01
+    6-well   plate positions range from A01 to B03
+    24-well  plate positions range from A01 to D06
+    96-well  plate positions range from A01 to H12
+    384-well plate positions range from A01 to P24
     """
 
     container = ParentalKey(
@@ -204,7 +204,7 @@ class Well(Model):
         db_column='container_code',
         editable=False,
         on_delete=PROTECT,
-        related_name='wells',
+        related_name='positions',
         to_field='code',
     )
     row = CheckedCharField(
@@ -222,7 +222,7 @@ class Well(Model):
         related_name='sources',
     )
 
-    objects = WellManager()
+    objects = PositionManager()
 
     class Meta(TypedModelMeta):
         constraints: ClassVar = [
@@ -261,18 +261,18 @@ class Plan(Model):
 @register_snippet
 class Transfer(Model):
     """
-    Transfer from one well to another.
+    Movement from one position to another.
 
     The same (source, sink) may appear multiple times in the same plan to enable transferring
-    a volume exceeding the pipette or tip size.
+    a volume exceeding pipette or tip size.
 
     The same (source, sink) may appear in multiple plans to enable multiple rounds of
     liquid transfer and drying.
     """
 
     plan = ForeignKey(Plan, on_delete=PROTECT, related_name='transfers')
-    source = ForeignKey(Well, on_delete=PROTECT, related_name='+')
-    sink = ForeignKey(Well, on_delete=PROTECT, related_name='+')
+    source = ForeignKey(Position, on_delete=PROTECT, related_name='+')
+    sink = ForeignKey(Position, on_delete=PROTECT, related_name='+')
 
     def __str__(self) -> str:
         return f'{self.source} -> {self.sink}'

--- a/wellplated/models.py
+++ b/wellplated/models.py
@@ -6,6 +6,7 @@ from typing import ClassVar, Self
 from django.contrib.auth.models import User
 from django.db.models import (
     PROTECT,
+    BooleanField,
     CharField,
     DateTimeField,
     ForeignKey,
@@ -77,7 +78,7 @@ class Format(Model):  # type: ignore[django-manager-missing]
     # in its own GeneratedFields, and Well can ForeignKey and constrain on them.
     bottom_right_prefix = GeneratedField(
         db_persist=True,
-        editable=False,
+        #editable=False,
         expression=Concat(
             'bottom_row', LPad(Cast('right_column', CharField()), 2, Value('0')), 'prefix'
         ),
@@ -86,6 +87,8 @@ class Format(Model):  # type: ignore[django-manager-missing]
         ),
         unique=True,
     )
+    
+    attribute_example = 'Attribute example'
 
     created_at = DateTimeField(auto_now_add=True)
 

--- a/wellplated/tests.py
+++ b/wellplated/tests.py
@@ -6,7 +6,7 @@ from pytest import mark, raises
 from pytest_django.fixtures import DjangoAssertNumQueries
 from pytest_mock import MockerFixture
 
-from wellplated.models import Container, Format, Plan, Transfer, User, Well
+from wellplated.models import Container, Format, Plan, Position, Transfer, User
 
 
 def get_test_user() -> 'User':
@@ -21,7 +21,10 @@ def test_untracked_data() -> None:
 
     assert Container.objects.filter(code__in=('A01start0000000', 'A01end000000999')).count() == 2
 
-    assert Well.objects.filter(container_id__in=('A01start0000000', 'A01end000000999')).count() == 2
+    assert (
+        Position.objects.filter(container_id__in=('A01start0000000', 'A01end000000999')).count()
+        == 2
+    )
 
 
 @mark.django_db
@@ -34,8 +37,8 @@ def test_str(django_assert_num_queries: DjangoAssertNumQueries) -> None:
         start_container = Container.objects.get(format__pk=start_format.pk)
         assert str(start_container) == 'start0000000'
     with django_assert_num_queries(1):
-        start_well = Well.objects.get(container__pk=start_container.pk)
-        assert str(start_well) == 'start0000000.A01'
+        start_position = Position.objects.get(container__pk=start_container.pk)
+        assert str(start_position) == 'start0000000.A01'
 
 
 @mark.django_db
@@ -111,18 +114,18 @@ def test_container_external_id() -> None:
 
 @mark.django_db
 def test_container_dot_position(mocker: MockerFixture) -> None:
-    """Containers must accept attribute dot labels to access wells."""
+    """Containers must accept attribute dot notation to access positions."""
     wip_tube = Container.objects.create(
         format=Format.objects.create(
             bottom_row='P', right_column=24, prefix='wip', purpose='work-in-process-tube'
         )
     )
-    mock_wells = mocker.patch.object(Container, 'wells', autospec=True)
+    mock_positions = mocker.patch.object(Container, 'positions', autospec=True)
     _ = wip_tube.A1  # top left without zero padding
     _ = wip_tube.A01  # top left with zero padding
     _ = wip_tube.H12  # bottom right of 8 * 12 == 96-well plate
     _ = wip_tube.P24  # bottom right of 16 * 24 == 384-well plate
-    assert mock_wells.method_calls == [
+    assert mock_positions.method_calls == [
         mocker.call.get(row='A', column=1),
         mocker.call.get(row='A', column=1),
         mocker.call.get(row='H', column=12),
@@ -156,10 +159,10 @@ def test_container_dot_methods() -> None:
 @mark.parametrize(
     ('row', 'column'), [('@', 1), ('Q', 1), ('A', -1), ('A', 0), ('A', 25), ('A', 100), ('AA', 1)]
 )
-def test_well_creation_range(row: int, column: str) -> None:
-    """Wells must stay in range."""
+def test_position_creation_range(row: int, column: str) -> None:
+    """Positions must stay in range."""
     with raises(IntegrityError):
-        Well.objects.create(
+        Position.objects.create(
             container=Container.objects.create(
                 format=Format.objects.create(prefix='pl', purpose='plate')
             ),
@@ -169,12 +172,12 @@ def test_well_creation_range(row: int, column: str) -> None:
 
 
 @mark.django_db
-def test_overlapping_well_creation() -> None:
-    """Wells must not overlap."""
+def test_overlapping_position_creation() -> None:
+    """Positions must not overlap."""
     plate = Container.objects.create(format=Format.objects.create(prefix='pl', purpose='plate'))
-    Well.objects.create(container=plate, row='A', column=1)
+    Position.objects.create(container=plate, row='A', column=1)
     with raises(IntegrityError):
-        Well.objects.create(container=plate, row='A', column=1)
+        Position.objects.create(container=plate, row='A', column=1)
 
 
 @mark.django_db
@@ -184,8 +187,10 @@ def test_plan_and_transfers() -> None:
     assert plan.created_by.username == 'test.user'
     assert str(plan).startswith('plan ')
 
-    transfer = Transfer.objects.create(plan=plan, source=Well.objects.start, sink=Well.objects.end)
-    assert set(Well.objects.start.sinks.all()) == {Well.objects.end}
-    assert set(Well.objects.end.sources.all()) == {Well.objects.start}
+    transfer = Transfer.objects.create(
+        plan=plan, source=Position.objects.start, sink=Position.objects.end
+    )
+    assert set(Position.objects.start.sinks.all()) == {Position.objects.end}
+    assert set(Position.objects.end.sources.all()) == {Position.objects.start}
     assert plan.transfers.get() == transfer
     assert str(transfer) == 'start0000000.A01 -> end000000999.A01'


### PR DESCRIPTION
### Background and Links
* While I like that "Well" is short and simple, the word is pretty plate-specific

### Changes and Testing
* Use "Position" to better support tubes (more for racks than individual tubes)
* Add a `justfile`:
```
(wellplated) cov@covbuntu:~/code/wellplated$ just push -f HEAD:reposition
git push https://${GITHUB_TOKEN}@github.com/$(just orgn)/$(just cona) -f HEAD:reposition
Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 4 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 368 bytes | 368.00 KiB/s, done.
Total 4 (delta 3), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.
To https://github.com/biobuddies/wellplated
   364dc1f..01f36e0  HEAD -> reposition
```

### Questions and Followup
* "Container" remains somewhat ambiguous in the context of a rack of tubes. Is a physical tube digitally modeled as a `Container`? Is a physical rack modeled as a `Container`? Are both modeled as `Container`s? I think the simple early answer is to say a physical tube is digitally modeled as a `Position`, and the rack (or even a set of racks) is digitally modeled as a `Container`. Followup work on rooms, fridges, freezers, incubators, liquid handler decks, etc. will likely bring additional levels of hierarchy and may help answer the question of how to best model tubes in racks.
* Autogenerating a multi-project `justfile` using `cookiecutter`