### PR TITLE
Drop Wagtail

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -10,9 +10,7 @@ jobs:
                       && a \
                       && pcam --color always --show-diff-on-failure
             - run: .venv/bin/python -m manage check
-            - run: |
-                  .venv/bin/python -m pytest --cov=wellplated \
-                      --cov-report=term-missing:skip-covered
+            - run: .venv/bin/python -m pytest
             - run: .venv/bin/python -m build
             - run: .venv/bin/twine check dist/*
 

--- a/demodj/settings.py
+++ b/demodj/settings.py
@@ -44,19 +44,6 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django_extensions',
-    'wagtail.contrib.forms',
-    'wagtail.contrib.redirects',
-    'wagtail.embeds',
-    'wagtail.sites',
-    'wagtail.users',
-    'wagtail.snippets',
-    'wagtail.documents',
-    'wagtail.images',
-    'wagtail.search',
-    'wagtail.admin',
-    'wagtail',
-    'modelcluster',
-    'taggit',
     'wellplated',
 ]
 
@@ -68,7 +55,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 ]
 
 ROOT_URLCONF = 'demodj.urls'
@@ -115,10 +101,10 @@ AUTH_PASSWORD_VALIDATORS = [
 # Display 24-hour time with short Z timezone/offset abbreviation.
 # Use RFC 3339 ` ` space separator between date and time over ISO 8601 `T` for easier reading.
 # Seconds are probably unnecessarily precise for in-vitro but relevant for in-silico.
-DATETIME_FORMAT = SHORT_DATETIME_FORMAT = WAGTAIL_DATETIME_FORMAT = '%Y-%m-%d %H:%M:%SZ'
-DATE_FORMAT = SHORT_DATE_FORMAT = WAGTAIL_DATE_FORMAT = 'Y-m-d'
+DATETIME_FORMAT = SHORT_DATETIME_FORMAT = '%Y-%m-%d %H:%M:%SZ'
+DATE_FORMAT = SHORT_DATE_FORMAT = 'Y-m-d'
 LANGUAGE_CODE = 'en-us'
-TIME_FORMAT = WAGTAIL_TIME_FORMAT = '%H:%M:%SZ'
+TIME_FORMAT = '%H:%M:%SZ'
 TIME_ZONE = 'UTC'
 # Django's "InternationalizatioN" (I18N) setting is really about language translation; support for
 # different spellings of English, and different languages, would be welcome additions.
@@ -143,11 +129,6 @@ MEDIA_URL = '/media/'
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
-
-WAGTAIL_SITE_NAME = 'Well Plated Demo'
-WAGTAILADMIN_BASE_URL = 'off'
-
-FORMS_URLFIELD_ASSUME_HTTPS = True
 
 SHELL_PLUS_PRINT_SQL_TRUNCATE = None
 

--- a/demodj/urls.py
+++ b/demodj/urls.py
@@ -19,14 +19,6 @@ Including another URLconf
 """
 
 from django.contrib import admin
-from django.urls import include, path
-from wagtail import urls as wagtail_urls
-from wagtail.admin import urls as wagtailadmin_urls
-from wagtail.documents import urls as wagtaildocs_urls
+from django.urls import path
 
-urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('manage/', include(wagtailadmin_urls)),
-    path('documents/', include(wagtaildocs_urls)),
-    path('pages/', include(wagtail_urls)),
-]
+urlpatterns = [path('admin/', admin.site.urls)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = 'demodj.settings'
+addopts = '--cov=wellplated --cov-report=term-missing:skip-covered --verbose'
 django_debug_mode = 'keep'
 python_files = ['tests.py', 'test_*.py']
 


### PR DESCRIPTION
### Background and Links
* Wagtail is cool but also brings complications and slowdowns like unsquashed migrations

### Changes and Testing
* Drop Wagtail
* Ease pytest argument reuse

### Questions and Followup
* Could revert this commit and add Wagtail back once database constraints and stuff are sorted. Or maybe it'd be better to demonstrate how documents can be version controlled in git.